### PR TITLE
[STS-7] Deployment filebeat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,6 @@ worker_files
 
 *.db
 .DS_Store
+
+#filebeat stuff
+data

--- a/deployment/filebeat.yml
+++ b/deployment/filebeat.yml
@@ -1,0 +1,29 @@
+# @lukrzak please modify the config in here
+# ============================ Filebeat Inputs =============================
+
+filebeat.inputs:
+  - type: log
+    enabled: true
+    # Paths to the log files you want to collect for testing
+    paths:
+      - /home/stos/stos.log
+    # Optional additional fields for the log event
+    fields:
+      environment: production
+      service: stos
+
+
+# =========================== General Settings ===========================
+
+output.file:
+  path: "/home/stos/"
+  filename: "filebeat_output"
+
+# ======================= Optional Logging Configuration =======================
+logging.level: debug  # Set to debug for more detailed output
+logging.to_files: true
+logging.files:
+  path: /home/stos
+  name: filebeat.log
+  keepfiles: 7
+  permissions: 0644

--- a/deployment/shell.nix
+++ b/deployment/shell.nix
@@ -10,5 +10,6 @@ pkgs.mkShellNoCC {
       python-pkgs.requests
     ]))
     pkgs.sqlite
+    pkgs.filebeat
   ];
 }


### PR DESCRIPTION
Added filebeat installation running directly together with stos, started dumping stos logs to file, filebeat correctly intercepts them and send them where we want, currently to a file only. We'll need to do some fancier configuration @lukrzak 